### PR TITLE
Add loading overlay transitions

### DIFF
--- a/password-helper-electron/public/index.html
+++ b/password-helper-electron/public/index.html
@@ -232,6 +232,28 @@
       75%   {transform:translateX(-50%) translateX(5px);}
     }
     #toast-container.shake{animation:shake 0.5s ease;}
+
+    /* ==== LOADING OVERLAY ==== */
+    #loading-overlay {
+      position:fixed; top:0; left:0;
+      width:100%; height:100%;
+      background:rgba(0,0,0,0.6);
+      backdrop-filter:blur(4px);
+      display:flex; align-items:center; justify-content:center;
+      opacity:0; transition:opacity 0.5s ease;
+      z-index:10000;
+    }
+    #loading-overlay .loader {
+      display:flex; flex-direction:column; align-items:center;
+    }
+    #loading-overlay .lock { font-size:32px; margin-bottom:12px; }
+    #loading-overlay .spinner {
+      width:32px; height:32px; border:3px solid rgba(255,255,255,0.4);
+      border-top-color:#fff; border-radius:50%;
+      animation:spin 1s linear infinite;
+    }
+    @keyframes spin { from{transform:rotate(0);} to{transform:rotate(360deg);} }
+    .hidden{ display:none; }
   </style>
 
   <!-- zxcvbn for crack‐time + dictionary feedback -->
@@ -240,6 +262,12 @@
 <body>
   <script> const { ipcRenderer } = require('electron'); </script>
   <canvas id="matrixCanvas"></canvas>
+  <div id="loading-overlay" class="hidden">
+    <div class="loader">
+      <span class="lock">🔒</span>
+      <div class="spinner"></div>
+    </div>
+  </div>
 
   <!-- TITLEBAR -->
   <div class="titlebar">
@@ -558,10 +586,22 @@
     window.addEventListener('resize',initMatrix);
 
     window.addEventListener('DOMContentLoaded', () => {
-      requestAnimationFrame(() => document.body.classList.add('loaded'));
+      const overlay = document.getElementById('loading-overlay');
+      requestAnimationFrame(() => {
+        document.body.classList.add('loaded');
+        if (overlay) {
+          overlay.style.opacity = '0';
+          setTimeout(() => overlay.classList.add('hidden'), 500);
+        }
+      });
     });
 
     function transitionTo(url){
+      const overlay = document.getElementById('loading-overlay');
+      if (overlay){
+        overlay.classList.remove('hidden');
+        requestAnimationFrame(() => overlay.style.opacity = '1');
+      }
       document.body.classList.remove('loaded');
       setTimeout(()=>{ window.location.href=url; }, 500);
     }

--- a/password-helper-electron/public/login.html
+++ b/password-helper-electron/public/login.html
@@ -105,11 +105,39 @@
     .btn.outline:hover {
       background:rgba(114,137,218,0.2);
     }
+
+    /* ==== LOADING OVERLAY ==== */
+    #loading-overlay {
+      position:fixed; top:0; left:0;
+      width:100%; height:100%;
+      background:rgba(0,0,0,0.6);
+      backdrop-filter:blur(4px);
+      display:flex; align-items:center; justify-content:center;
+      opacity:0; transition:opacity 0.5s ease;
+      z-index:10000;
+    }
+    #loading-overlay .loader {
+      display:flex; flex-direction:column; align-items:center;
+    }
+    #loading-overlay .lock { font-size:32px; margin-bottom:12px; }
+    #loading-overlay .spinner {
+      width:32px; height:32px; border:3px solid rgba(255,255,255,0.4);
+      border-top-color:#fff; border-radius:50%;
+      animation:spin 1s linear infinite;
+    }
+    @keyframes spin { from{transform:rotate(0);} to{transform:rotate(360deg);} }
+    .hidden{ display:none; }
   </style>
 </head>
 <body>
   <script> const { ipcRenderer } = require('electron'); </script>
   <canvas id="matrixCanvas"></canvas>
+  <div id="loading-overlay" class="hidden">
+    <div class="loader">
+      <span class="lock">🔒</span>
+      <div class="spinner"></div>
+    </div>
+  </div>
 
   <!-- TITLEBAR -->
   <div class="titlebar">
@@ -168,11 +196,18 @@
 
     // FADE-IN & SWIPE-IN ANIMATION
     window.addEventListener('DOMContentLoaded', () => {
-      requestAnimationFrame(() => document.body.classList.add('loaded'));
-      // slightly delay for smoother reveal
-      setTimeout(() => {
-        document.getElementById('login-screen').classList.add('active');
-      }, 200);
+      const overlay = document.getElementById('loading-overlay');
+      requestAnimationFrame(() => {
+        document.body.classList.add('loaded');
+        if (overlay) {
+          overlay.style.opacity = '0';
+          setTimeout(() => overlay.classList.add('hidden'), 500);
+        }
+        // slightly delay for smoother reveal
+        setTimeout(() => {
+          document.getElementById('login-screen').classList.add('active');
+        }, 200);
+      });
     });
 
     // LOGIN / SKIP / TOGGLE
@@ -202,6 +237,11 @@
     };
 
     function transitionTo(url){
+      const overlay = document.getElementById('loading-overlay');
+      if (overlay){
+        overlay.classList.remove('hidden');
+        requestAnimationFrame(() => overlay.style.opacity = '1');
+      }
       document.body.classList.remove('loaded');
       setTimeout(()=>{ window.location.href = url; }, 500);
     }

--- a/password-helper-electron/public/vault.html
+++ b/password-helper-electron/public/vault.html
@@ -190,11 +190,39 @@
       75%      { transform: translateX(-50%) translateX(5px); }
     }
     #toast-container.shake { animation: shake 0.5s ease; }
+
+    /* ==== LOADING OVERLAY ==== */
+    #loading-overlay {
+      position:fixed; top:0; left:0;
+      width:100%; height:100%;
+      background:rgba(0,0,0,0.6);
+      backdrop-filter:blur(4px);
+      display:flex; align-items:center; justify-content:center;
+      opacity:0; transition:opacity 0.5s ease;
+      z-index:10000;
+    }
+    #loading-overlay .loader {
+      display:flex; flex-direction:column; align-items:center;
+    }
+    #loading-overlay .lock { font-size:32px; margin-bottom:12px; }
+    #loading-overlay .spinner {
+      width:32px; height:32px; border:3px solid rgba(255,255,255,0.4);
+      border-top-color:#fff; border-radius:50%;
+      animation:spin 1s linear infinite;
+    }
+    @keyframes spin { from{transform:rotate(0);} to{transform:rotate(360deg);} }
+    .hidden{ display:none; }
   </style>
 </head>
 <body>
   <script> const { ipcRenderer } = require('electron'); </script>
   <canvas id="matrixCanvas"></canvas>
+  <div id="loading-overlay" class="hidden">
+    <div class="loader">
+      <span class="lock">🔒</span>
+      <div class="spinner"></div>
+    </div>
+  </div>
 
   <!-- TITLEBAR -->
   <div class="titlebar">
@@ -394,10 +422,22 @@
     }
 
     window.addEventListener('DOMContentLoaded', () => {
-      requestAnimationFrame(() => document.body.classList.add('loaded'));
+      const overlay = document.getElementById('loading-overlay');
+      requestAnimationFrame(() => {
+        document.body.classList.add('loaded');
+        if (overlay) {
+          overlay.style.opacity = '0';
+          setTimeout(() => overlay.classList.add('hidden'), 500);
+        }
+      });
     });
 
     function transitionTo(url){
+      const overlay = document.getElementById('loading-overlay');
+      if (overlay){
+        overlay.classList.remove('hidden');
+        requestAnimationFrame(() => overlay.style.opacity = '1');
+      }
       document.body.classList.remove('loaded');
       setTimeout(()=>{ window.location.href=url; }, 500);
     }

--- a/password-helper-electron/public/vault_view.html
+++ b/password-helper-electron/public/vault_view.html
@@ -262,11 +262,39 @@
       75%      { transform: translateX(-50%) translateX(5px); }
     }
     #toast-container.shake { animation: shake 0.5s ease; }
+
+    /* ==== LOADING OVERLAY ==== */
+    #loading-overlay {
+      position:fixed; top:0; left:0;
+      width:100%; height:100%;
+      background:rgba(0,0,0,0.6);
+      backdrop-filter:blur(4px);
+      display:flex; align-items:center; justify-content:center;
+      opacity:0; transition:opacity 0.5s ease;
+      z-index:10000;
+    }
+    #loading-overlay .loader {
+      display:flex; flex-direction:column; align-items:center;
+    }
+    #loading-overlay .lock { font-size:32px; margin-bottom:12px; }
+    #loading-overlay .spinner {
+      width:32px; height:32px; border:3px solid rgba(255,255,255,0.4);
+      border-top-color:#fff; border-radius:50%;
+      animation:spin 1s linear infinite;
+    }
+    @keyframes spin { from{transform:rotate(0);} to{transform:rotate(360deg);} }
+    .hidden{ display:none; }
   </style>
 </head>
 <body>
   <script> const { ipcRenderer } = require('electron'); </script>
   <canvas id="matrixCanvas"></canvas>
+  <div id="loading-overlay" class="hidden">
+    <div class="loader">
+      <span class="lock">🔒</span>
+      <div class="spinner"></div>
+    </div>
+  </div>
 
   <!-- TITLEBAR -->
   <div class="titlebar">
@@ -497,10 +525,22 @@
     renderAccordion();
 
     window.addEventListener('DOMContentLoaded', () => {
-      requestAnimationFrame(() => document.body.classList.add('loaded'));
+      const overlay = document.getElementById('loading-overlay');
+      requestAnimationFrame(() => {
+        document.body.classList.add('loaded');
+        if (overlay) {
+          overlay.style.opacity = '0';
+          setTimeout(() => overlay.classList.add('hidden'), 500);
+        }
+      });
     });
 
     function transitionTo(url){
+      const overlay = document.getElementById('loading-overlay');
+      if (overlay){
+        overlay.classList.remove('hidden');
+        requestAnimationFrame(() => overlay.style.opacity = '1');
+      }
       document.body.classList.remove('loaded');
       setTimeout(()=>{ window.location.href=url; }, 500);
     }


### PR DESCRIPTION
## Summary
- add loading overlay element across pages
- style overlay and spinner
- dim/blur body during page transitions
- fade overlay in `transitionTo`
- hide overlay after new page loads

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684056d79874832cad77079770d5d86f